### PR TITLE
feat: add support for Discord.js 13

### DIFF
--- a/e2e.spec.ts
+++ b/e2e.spec.ts
@@ -18,9 +18,7 @@ const role: string = process.env.ROLE;
 const channel: string = process.env.CHANNEL;
 
 const client = new Client({
-  ws: {
-    intents: Intents.FLAGS.GUILDS | Intents.FLAGS.GUILD_VOICE_STATES,
-  },
+  intents: Intents.FLAGS.GUILDS | Intents.FLAGS.GUILD_VOICE_STATES,
 });
 
 const manager = new VoiceRoleManager({

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -28,7 +28,7 @@ describe("VoiceRole", () => {
   });
 
   function voiceEvent(channelId?: Snowflake): VoiceState {
-    return { member: mockMember, channelID: channelId } as any;
+    return { member: mockMember, channelId: channelId } as any;
   }
 
   describe("when the user joins a channel", () => {

--- a/index.ts
+++ b/index.ts
@@ -21,18 +21,18 @@ export default class VoiceRoleManager {
       /* TODO: Can this happen? */
       return;
     }
-    if (oldState.channelID) {
+    if (oldState.channelId) {
       /* This is the channel that the member has left. */
-      const roles = this.roles(oldState.channelID);
+      const roles = this.roles(oldState.channelId);
       roles.forEach((role) =>
         oldState.member.roles.remove(role).catch((e) => {
           console.error(`Could not delete member from role: ${e}`);
         })
       );
     }
-    if (newState.channelID) {
+    if (newState.channelId) {
       /* This is the channel that the member has joined. */
-      const roles = this.roles(newState.channelID);
+      const roles = this.roles(newState.channelId);
       roles.forEach((role) =>
         newState.member.roles.add(role).catch((e) => {
           console.error(`Could not add member to role: ${e}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/eslint-plugin": "^4.13.0",
         "@typescript-eslint/parser": "^4.13.0",
         "chai": "^4.2.0",
-        "discord.js": "^12.0.0",
+        "discord.js": "^13.0.0",
         "eslint": "^7.18.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.3.1",
@@ -33,7 +33,7 @@
         "node": ">=16.6"
       },
       "peerDependencies": {
-        "discord.js": "^12.0.0"
+        "discord.js": "^13.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -97,11 +97,37 @@
         "node": ">=12"
       }
     },
-    "node_modules/@discordjs/collection": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ==",
+    "node_modules/@discordjs/builders": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.5.0.tgz",
+      "integrity": "sha512-HP5y4Rqw68o61Qv4qM5tVmDbWi4mdTFftqIOGRo33SNPpLJ1Ga3KEIR2ibKofkmsoQhEpLmopD1AZDs3cKpHuw==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.1",
+        "discord-api-types": "^0.22.0",
+        "ow": "^0.27.0",
+        "ts-mixer": "^6.0.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/builders/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.2.1.tgz",
+      "integrity": "sha512-vhxqzzM8gkomw0TYRF3tgx7SwElzUlXT/Aa41O7mOcyN6wIJfj5JmDWaO5XGKsGSsNx7F3i5oIlrucCCWV1Nog==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@discordjs/form-data": {
       "version": "3.0.1",
@@ -199,6 +225,28 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.4.tgz",
+      "integrity": "sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -322,6 +370,15 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -669,18 +726,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -1542,24 +1587,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.22.0.tgz",
+      "integrity": "sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/discord.js": {
-      "version": "12.5.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.3.tgz",
-      "integrity": "sha512-D3nkOa/pCkNyn6jLZnAiJApw2N9XrIsXUAdThf01i7yrEuqUmDGc7/CexVWwEcgbQR97XQ+mcnqJpmJ/92B4Aw==",
-      "deprecated": "no longer supported",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.1.0.tgz",
+      "integrity": "sha512-gxO4CXKdHpqA+WKG+f5RNnd3srTDj5uFJHgOathksDE90YNq/Qijkd2WlMgTTMS6AJoEnHxI7G9eDQHCuZ+xDA==",
       "dev": true,
       "dependencies": {
-        "@discordjs/collection": "^0.1.6",
+        "@discordjs/builders": "^0.5.0",
+        "@discordjs/collection": "^0.2.1",
         "@discordjs/form-data": "^3.0.1",
-        "abort-controller": "^3.0.0",
+        "@sapphire/async-queue": "^1.1.4",
+        "@types/ws": "^7.4.7",
+        "discord-api-types": "^0.22.0",
         "node-fetch": "^2.6.1",
-        "prism-media": "^1.2.9",
-        "setimmediate": "^1.0.5",
-        "tweetnacl": "^1.0.3",
-        "ws": "^7.4.4"
+        "ws": "^7.5.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.6.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/doctrine": {
@@ -1959,15 +2013,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3003,6 +3048,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -3579,6 +3630,53 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ow": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
+      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.1",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "type-fest": "^1.2.1",
+        "vali-date": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ow/node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ow/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3760,32 +3858,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/prism-media": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.2.tgz",
-      "integrity": "sha512-L6UsGHcT6i4wrQhFF1aPK+MNYgjRqR2tUoIqEY+CG1NqVkMjPRKzS37j9f8GiYPlD6wG9ruBj+q5Ax+bH8Ik1g==",
-      "dev": true,
-      "peerDependencies": {
-        "@discordjs/opus": "^0.5.0",
-        "ffmpeg-static": "^4.2.7 || ^3.0.0 || ^2.4.0",
-        "node-opus": "^0.3.3",
-        "opusscript": "^0.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@discordjs/opus": {
-          "optional": true
-        },
-        "ffmpeg-static": {
-          "optional": true
-        },
-        "node-opus": {
-          "optional": true
-        },
-        "opusscript": {
-          "optional": true
-        }
       }
     },
     "node_modules/process-nextick-args": {
@@ -4161,12 +4233,6 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4611,6 +4677,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
+      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==",
+      "dev": true
+    },
     "node_modules/ts-node": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.0.tgz",
@@ -4687,12 +4759,6 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4779,6 +4845,15 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -5122,10 +5197,31 @@
         "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
+    "@discordjs/builders": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.5.0.tgz",
+      "integrity": "sha512-HP5y4Rqw68o61Qv4qM5tVmDbWi4mdTFftqIOGRo33SNPpLJ1Ga3KEIR2ibKofkmsoQhEpLmopD1AZDs3cKpHuw==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^4.0.1",
+        "discord-api-types": "^0.22.0",
+        "ow": "^0.27.0",
+        "ts-mixer": "^6.0.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "@discordjs/collection": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.2.1.tgz",
+      "integrity": "sha512-vhxqzzM8gkomw0TYRF3tgx7SwElzUlXT/Aa41O7mOcyN6wIJfj5JmDWaO5XGKsGSsNx7F3i5oIlrucCCWV1Nog==",
       "dev": true
     },
     "@discordjs/form-data": {
@@ -5204,6 +5300,18 @@
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
+    },
+    "@sapphire/async-queue": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.4.tgz",
+      "integrity": "sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA==",
+      "dev": true
+    },
+    "@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.2",
@@ -5328,6 +5436,15 @@
       "requires": {
         "@types/chai": "*",
         "@types/sinon": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@typescript-eslint/eslint-plugin": {
@@ -5526,15 +5643,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
     },
     "acorn": {
       "version": "7.4.1",
@@ -6202,20 +6310,26 @@
         "path-type": "^4.0.0"
       }
     },
+    "discord-api-types": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.22.0.tgz",
+      "integrity": "sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg==",
+      "dev": true
+    },
     "discord.js": {
-      "version": "12.5.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.3.tgz",
-      "integrity": "sha512-D3nkOa/pCkNyn6jLZnAiJApw2N9XrIsXUAdThf01i7yrEuqUmDGc7/CexVWwEcgbQR97XQ+mcnqJpmJ/92B4Aw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.1.0.tgz",
+      "integrity": "sha512-gxO4CXKdHpqA+WKG+f5RNnd3srTDj5uFJHgOathksDE90YNq/Qijkd2WlMgTTMS6AJoEnHxI7G9eDQHCuZ+xDA==",
       "dev": true,
       "requires": {
-        "@discordjs/collection": "^0.1.6",
+        "@discordjs/builders": "^0.5.0",
+        "@discordjs/collection": "^0.2.1",
         "@discordjs/form-data": "^3.0.1",
-        "abort-controller": "^3.0.0",
+        "@sapphire/async-queue": "^1.1.4",
+        "@types/ws": "^7.4.7",
+        "discord-api-types": "^0.22.0",
         "node-fetch": "^2.6.1",
-        "prism-media": "^1.2.9",
-        "setimmediate": "^1.0.5",
-        "tweetnacl": "^1.0.3",
-        "ws": "^7.4.4"
+        "ws": "^7.5.1"
       }
     },
     "doctrine": {
@@ -6510,12 +6624,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -7319,6 +7427,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -7759,6 +7873,37 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "ow": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
+      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^4.0.1",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "type-fest": "^1.2.1",
+        "vali-date": "^1.0.0"
+      },
+      "dependencies": {
+        "dot-prop": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+          "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+          "dev": true
+        }
+      }
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7881,13 +8026,6 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
-    },
-    "prism-media": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.2.tgz",
-      "integrity": "sha512-L6UsGHcT6i4wrQhFF1aPK+MNYgjRqR2tUoIqEY+CG1NqVkMjPRKzS37j9f8GiYPlD6wG9ruBj+q5Ax+bH8Ik1g==",
-      "dev": true,
-      "requires": {}
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -8149,12 +8287,6 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -8512,6 +8644,12 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
+    "ts-mixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
+      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==",
+      "dev": true
+    },
     "ts-node": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.0.tgz",
@@ -8554,12 +8692,6 @@
       "requires": {
         "tslib": "^1.8.1"
       }
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -8620,6 +8752,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "ISC",
   "peerDependencies": {
-    "discord.js": "^12.0.0"
+    "discord.js": "^13.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",
@@ -48,7 +48,7 @@
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
     "chai": "^4.2.0",
-    "discord.js": "^12.0.0",
+    "discord.js": "^13.0.0",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.3.1",


### PR DESCRIPTION
This commit upgrades the required Discord.js version to 13.
Unfortunately they changed the ABI (the channelID field is now known as
channelId), thus it drops support for Discord.js 12 since there are
internal breaking changes that may cause the library to behave
improperly when using Discord.js 12.